### PR TITLE
Fix link to tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # React on Rails Tutorial With SSR, HMR fast refresh, and TypeScript
-Each commit demonstrates a step in the [React on Rails Tutorial](https://github.com/shakacode/react_on_rails/blob/master/docs/tutorial.md).
+Each commit demonstrates a step in the [React on Rails Tutorial](https://github.com/shakacode/react_on_rails/blob/master/docs/basics/tutorial.md).
 
 Please ⭐️ this repo if you find this useful.
 


### PR DESCRIPTION
The tutorial moved in shakacode/react_on_rails#1335
This PR updates the link

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails_tutorial_with_ssr_and_hmr_fast_refresh/10)
<!-- Reviewable:end -->
